### PR TITLE
Don't set the global twice

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -183,9 +183,7 @@
     },
   }
 
-  window.Embroidery = Embroidery
-
-  window.Embroidery.start()
+  Embroidery.start()
 
   return Embroidery
 })


### PR DESCRIPTION
The UMD declaration at the top already sets the `Embroidery` global (unless another module system is already in place).