### PR TITLE
Use relative URLs that don't require a rewrite

### DIFF
--- a/biff.html
+++ b/biff.html
@@ -1,6 +1,6 @@
 <div data-controller="biff">
   <h1>Biff</h1>
-  <a href="/meep">Meep</a>
+  <a href="./meep.html">Meep</a>
   <div data-action="click->toggle">
     <span data-target="bjorn">Björn 123</span>
   </div>

--- a/index.html
+++ b/index.html
@@ -4,9 +4,9 @@
     <title>Embroidery</title>
   </head>
 
-  <script src="/lib/something.js"></script>
-  <script src="/lib/index.js"></script>
-  <!-- <script src="/lib/drag-reduction.js"></script> -->
+  <script src="./lib/something.js"></script>
+  <script src="./lib/index.js"></script>
+  <!-- <script src="./lib/drag-reduction.js"></script> -->
   <body>
     <div data-controller="test">
       <input data-target="mingo" value="anton@antonnyman.se" />
@@ -19,11 +19,11 @@
       </div>
     </div>
 
-    <a href="/kading">Kading</a>
-    <a href="/heavy">Heavy</a>
+    <a href="./kading.html">Kading</a>
+    <a href="./heavy.html">Heavy</a>
     <a href="https://antonnyman.se">Out</a>
 
-    <div data-partial="/biff"></div>
+    <div data-partial="./biff.html"></div>
 
     <div data-controller="booty"></div>
   </body>


### PR DESCRIPTION
The previous implementation required the examples to be hosted at the root. Using relative URLs, it can also be hosted in a subfolder.