### PR TITLE
Explicitly set charset

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8" />
     <title>Embroidery</title>
   </head>
 


### PR DESCRIPTION
You should always set the charset explicitly. Otherwise browsers will usually assume ISO-8859-1.